### PR TITLE
Updated ruby version required to 2.3

### DIFF
--- a/jumbo-jekyll-theme.gemspec
+++ b/jumbo-jekyll-theme.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   end
 
   # spec.files         = []
-  spec.required_ruby_version = '>=2.4.2'
+  spec.required_ruby_version = '>=2.3'
   
   spec.add_runtime_dependency 'jekyll', '~> 3.7', '>= 3.7.0'
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.2"


### PR DESCRIPTION
The theme doesn't require ruby 2.4.2. Set a sane requirement to ruby 2.3 which is a stable supported version.