### PR TITLE
Removing jekyll-sitemap from the theme _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -131,7 +131,6 @@ relative_links:
   collections: false
 plugins:
   - jekyll-seo-tag
-  - jekyll-sitemap
   - uglifier
   - jekyll-assets
   - jekyll-theme-assets-updated

--- a/jumbo-jekyll-theme.gemspec
+++ b/jumbo-jekyll-theme.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |spec|
     # Main Spec Info
     spec.name          = "jumbo-jekyll-theme"
-    spec.version       = "5.6.6"
+    spec.version       = "5.6.7"
     spec.authors       = ["Kyle Kirkby"]
     spec.email         = ["kyle.kirkby@linaro.org"]
     spec.summary       = %q{This is a Bootstrap 3 Jekyll Theme built for Linaro Static Websites}

--- a/jumbo-jekyll-theme.gemspec
+++ b/jumbo-jekyll-theme.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |spec|
     # Main Spec Info
     spec.name          = "jumbo-jekyll-theme"
-    spec.version       = "5.6.8"
+    spec.version       = "5.6.9"
     spec.authors       = ["Kyle Kirkby"]
     spec.email         = ["kyle.kirkby@linaro.org"]
     spec.summary       = %q{This is a Bootstrap 3 Jekyll Theme built for Linaro Static Websites}
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
     # spec.add_runtime_dependency "jekyll-picture-tag-latest", ">0"
     spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.2"
     spec.add_runtime_dependency "jekyll-responsive-image", "~> 1.0.1"
+    spec.add_runtime_dependency "jekyll-sitemap", "1.4.0"
     spec.add_runtime_dependency "jekyll-readme-index", "0.2"
     spec.add_runtime_dependency "bootstrap-sass", "~> 3.4.1"
     spec.add_runtime_dependency "jekyll-redirect-from", "~> 0.12"

--- a/jumbo-jekyll-theme.gemspec
+++ b/jumbo-jekyll-theme.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
     # spec.add_runtime_dependency "jekyll-picture-tag-latest", ">0"
     spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.2"
     spec.add_runtime_dependency "jekyll-responsive-image", "~> 1.0.1"
-    spec.add_runtime_dependency "jekyll-sitemap", "1.4.0"
+    # spec.add_runtime_dependency "jekyll-sitemap", "1.4.0"
     spec.add_runtime_dependency "jekyll-readme-index", "0.2"
     spec.add_runtime_dependency "bootstrap-sass", "~> 3.4.1"
     spec.add_runtime_dependency "jekyll-redirect-from", "~> 0.12"

--- a/jumbo-jekyll-theme.gemspec
+++ b/jumbo-jekyll-theme.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |spec|
     # Main Spec Info
     spec.name          = "jumbo-jekyll-theme"
-    spec.version       = "5.6.7"
+    spec.version       = "5.6.8"
     spec.authors       = ["Kyle Kirkby"]
     spec.email         = ["kyle.kirkby@linaro.org"]
     spec.summary       = %q{This is a Bootstrap 3 Jekyll Theme built for Linaro Static Websites}
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
     # spec.add_runtime_dependency "jekyll-picture-tag-latest", ">0"
     spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.2"
     spec.add_runtime_dependency "jekyll-responsive-image", "~> 1.0.1"
-    spec.add_runtime_dependency "jekyll-sitemap", "~> 1.1"
     spec.add_runtime_dependency "jekyll-readme-index", "0.2"
     spec.add_runtime_dependency "bootstrap-sass", "~> 3.4.1"
     spec.add_runtime_dependency "jekyll-redirect-from", "~> 0.12"

--- a/jumbo-jekyll-theme.gemspec
+++ b/jumbo-jekyll-theme.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |spec|
     # Main Spec Info
     spec.name          = "jumbo-jekyll-theme"
-    spec.version       = "5.6.9.1"
+    spec.version       = "5.6.9.2"
     spec.authors       = ["Kyle Kirkby"]
     spec.email         = ["kyle.kirkby@linaro.org"]
     spec.summary       = %q{This is a Bootstrap 3 Jekyll Theme built for Linaro Static Websites}

--- a/jumbo-jekyll-theme.gemspec
+++ b/jumbo-jekyll-theme.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |spec|
     # Main Spec Info
     spec.name          = "jumbo-jekyll-theme"
-    spec.version       = "5.6.9"
+    spec.version       = "5.6.9.1"
     spec.authors       = ["Kyle Kirkby"]
     spec.email         = ["kyle.kirkby@linaro.org"]
     spec.summary       = %q{This is a Bootstrap 3 Jekyll Theme built for Linaro Static Websites}
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
     # spec.add_runtime_dependency "jekyll-picture-tag-latest", ">0"
     spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.2"
     spec.add_runtime_dependency "jekyll-responsive-image", "~> 1.0.1"
-    # spec.add_runtime_dependency "jekyll-sitemap", "1.4.0"
+    spec.add_runtime_dependency "jekyll-sitemap", "1.4.0"
     spec.add_runtime_dependency "jekyll-readme-index", "0.2"
     spec.add_runtime_dependency "bootstrap-sass", "~> 3.4.1"
     spec.add_runtime_dependency "jekyll-redirect-from", "~> 0.12"


### PR DESCRIPTION
Removing jekyll-sitemap from the theme _config.yml. This means that we can enabled the plugin on production builds only by adding:

```
plugins:
- jekyll-sitemap
```
to the `_config-production.yml` file.